### PR TITLE
#16: Adding support for custom manga column

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ Characters, Teams, Locations, Genre
 
 Story Arc, Volume, Number of Issues
 
+#### Text, but with a fixed set of permitted values:
+
+* Manga
+  * Values: No,Yes,YesAndRightToLeft
+  * Default Value: No
+
 #### Integer:
 
 Number of Issues, Volume

--- a/__init__.py
+++ b/__init__.py
@@ -24,7 +24,7 @@ class EmbedComicMetadataBase(InterfaceActionBase):
                            metadata from comic archives into calibre.'
     supported_platforms = ['windows', 'osx', 'linux']
     author              = 'dloraine'
-    version             = (1, 5, 2)
+    version             = (1, 6, 0)
     minimum_calibre_version = (3, 1, 1)
 
     #: This field defines the GUI plugin class that contains all the code

--- a/comicmetadata.py
+++ b/comicmetadata.py
@@ -191,6 +191,7 @@ class ComicMetadata:
         update_field("issueCount", field(prefs['count_column']))
         update_field("pageCount", field(prefs['pages_column']))
         update_field("webLink", get_link(field(prefs['comicvine_column'])))
+        update_field("manga", field(prefs['manga_column']))
 
     def convert_comic_md_to_calibre_md(self, comic_metadata):
         '''
@@ -285,6 +286,7 @@ class ComicMetadata:
         if prefs['get_image_sizes']:
             update_column(prefs['image_size_column'], self.get_picture_size())
         update_column(prefs['comicvine_column'], '<a href="{}">Comic Vine</a>'.format(co.webLink))
+        update_column(prefs['manga_column'], co.manga)
 
         self.comic_md_in_calibre_format = mi
 

--- a/ini.py
+++ b/ini.py
@@ -15,6 +15,7 @@ COMMENT_TYPE = {"is_multiple": False, "is_names": False, "datatype": "comments"}
 SERIES_TYPE = {"is_multiple": False, "is_names": False, "datatype": "series"}
 STORY_ARCH_TYPE = {"is_multiple": False, "is_names": False, "datatype": ["series", "text"]}
 NUMBER_TYPE = {"is_multiple": False, "is_names": False, "datatype": ["int", "text"]}
+ENUM_TYPE = {"is_multiple": False, "is_names": False, "datatype": ["enumeration", "text"]}
 
 # Some constants for ease of reading
 CONFIG_NAME = 0
@@ -81,7 +82,8 @@ def get_configuration():
                 ["count_column", _L['Number of issues:'], None, NUMBER_TYPE],
                 ["pages_column", _L['Pages:'], None, NUMBER_TYPE],
                 ["image_size_column", _L['Image size:'], None, FLOAT_TYPE],
-                ["comicvine_column", _L['Comicvine link:'], None, COMMENT_TYPE]
+                ["comicvine_column", _L['Comicvine link:'], None, COMMENT_TYPE],
+                ["manga_column", _L['Manga:'], None, ENUM_TYPE]
             ]
         },
         {

--- a/languages/de.py
+++ b/languages/de.py
@@ -23,6 +23,7 @@ de = {
     'Pages:': 'Seiten:',
     'Image size:': 'Bildgröße:',
     'Comicvine link:': 'Comicvine link:',
+    'Manga:': 'Manga:',
     # options (ini.py)
     "Options:": "Optionen:",
     'Write metadata in zip comment': 'Schreibe die Metadaten in den Zip-Kommentar',

--- a/languages/en.py
+++ b/languages/en.py
@@ -23,6 +23,7 @@ en = {
     'Pages:': 'Pages:',
     'Image size:': 'Image size:',
     'Comicvine link:': 'Comicvine link:',
+    'Manga:': 'Manga:',
     # options (ini.py)
     "Options:": "Options:",
     'Write metadata in zip comment': 'Write metadata in zip comment',


### PR DESCRIPTION
Adds support for a new custom column `manga`.

#### Text, but with a fixed set of permitted values:

* Manga
  * Values: No,Yes,YesAndRightToLeft
  * Default Value: No