### PR TITLE
add support for the GTIN element

### DIFF
--- a/comicbookinfo.py
+++ b/comicbookinfo.py
@@ -62,6 +62,7 @@ class ComicBookInfo:
         metadata.country = xlate('country')
         metadata.criticalRating = xlate('rating')
         metadata.tags = xlate('tags')
+        metadata.gtin = xlate('GTIN')
 
         # make sure credits and tags are at least empty lists and not None
         if metadata.credits is None:
@@ -132,5 +133,9 @@ class ComicBookInfo:
         assign('rating', metadata.criticalRating)
         assign('credits', metadata.credits)
         assign('tags', metadata.tags)
+
+        # check for isbn in identifiers
+        if 'isbn' in metadata.identifier:
+            assign('GTIN', metadata.identifier['isbn'])
 
         return cbi_container

--- a/comicinfoxml.py
+++ b/comicinfoxml.py
@@ -200,6 +200,7 @@ class ComicInfoXml:
         assign('Teams', md.teams)
         assign('Locations', md.locations)
         assign('ScanInformation', md.scanInfo)
+        assign('GTIN', md.gtin)
 
         #  loop and add the page entries under pages node
         if len(md.pages) > 0:

--- a/comicmetadata.py
+++ b/comicmetadata.py
@@ -173,6 +173,10 @@ class ComicMetadata:
             update_field("month", mi.pubdate.month)
             update_field("day", mi.pubdate.day)
 
+        # check for isbn in identifiers
+        if 'isbn' in mi.identifiers:
+            update_field("gtin", mi.identifiers['isbn'])
+
         # custom columns
         field = partial(self.db.field_for, book_id=self.book_id)
 

--- a/genericmetadata.py
+++ b/genericmetadata.py
@@ -95,6 +95,9 @@ class GenericMetadata:
         self.lastMark        = None
         self.coverImage      = None
 
+        # Anansi Project extensions
+        self.gtin            = None
+
     def overlay(self, new_md, overwrite=True):  # changed for the calibre plugin
         # Overlay a metadata object on this one
         # that is, when the new object has non-None
@@ -149,6 +152,7 @@ class GenericMetadata:
         assign("rights",            new_md.rights)
         assign("identifier",        new_md.identifier)
         assign("lastMark",          new_md.lastMark)
+        assign("gtin",              new_md.gtin)
 
         self.overlayCredits(new_md.credits, overwrite)
         # TODO


### PR DESCRIPTION
Adds support for writing the ISBN to the GTIN element in ComicInfo.xml, reading currently isn't supported because there has to be a way to identify the identifier (i.e is it ISBN or any other identifier) but I'm not sure how to do that at the moment.

I'm not entirely sure if this is the way it should be done but it does work on my end!

Fixes https://github.com/dickloraine/EmbedComicMetadata/issues/28